### PR TITLE
chore : Update RabbitMQ base image to trixi

### DIFF
--- a/bitnami/rabbitmq/3.13/debian-12/Dockerfile
+++ b/bitnami/rabbitmq/3.13/debian-12/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Broadcom, Inc. All Rights Reserved.
 # SPDX-License-Identifier: APACHE-2.0
 
-FROM docker.io/bitnami/minideb:bookworm
+FROM debian:trixie-slim
 
 ARG TARGETARCH
 


### PR DESCRIPTION
For https://github.com/h2oai/mlops/issues/45
Related to https://github.com/h2oai/h2oai-platform/pull/1469

Image is published at

`gcr.io/vorvan/h2oai/mlops-3rd-party/rabbitmq:3.13.3-debian-trixie-slim`